### PR TITLE
feat(experience): add links to experience cards with rotating labels

### DIFF
--- a/src/components/three/ExperiencePane.tsx
+++ b/src/components/three/ExperiencePane.tsx
@@ -16,7 +16,30 @@ const ExperiencePane = ({ onClose }: PaneProps) => {
   const groupRef = useRef<THREE.Group>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [direction, setDirection] = useState(0);
-  const { style, distanceFactor, isMobile } = useResponsivePane(1000, 600);
+  const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const { style, distanceFactor, isMobile, isDesktop, tier } = useResponsivePane(1000, 700);
+
+  // Reset image index when switching experience cards
+  useEffect(() => {
+    setCurrentImageIndex(0);
+  }, [currentIndex]);
+
+  // Get the current link and label based on the visible image
+  const getCurrentLinkInfo = () => {
+    const item = experienceData[currentIndex];
+    if (item.imageLinkLabels && item.imageLinks) {
+      return {
+        url: item.imageLinks[currentImageIndex] || item.imageLinks[0],
+        label: item.imageLinkLabels[currentImageIndex] || item.imageLinkLabels[0]
+      };
+    }
+    return {
+      url: item.link,
+      label: item.linkLabel
+    };
+  };
+
+  const linkInfo = getCurrentLinkInfo();
 
   const handleNext = () => {
     setDirection(1);
@@ -71,24 +94,24 @@ const ExperiencePane = ({ onClose }: PaneProps) => {
   return (
     <group ref={groupRef} position={[0, 0, 10]}>
       <Html transform position={[0, 0, 0]} distanceFactor={distanceFactor} zIndexRange={[100, 0]} style={style}>
-         <div className={`w-full h-full bg-black/90 text-white relative rounded-xl border border-cyan-500/50 backdrop-blur-md flex flex-col ${isMobile ? 'p-4' : 'p-6 max-w-4xl mx-auto'}`}>
+         <div className={`w-full h-full bg-black/90 text-white relative rounded-xl border border-cyan-500/50 backdrop-blur-md flex flex-col ${isDesktop ? 'p-3' : isMobile ? 'p-4' : 'p-4'}`}>
             {/* Header */}
             <div className="shrink-0 relative">
-                <button onClick={onClose} aria-label="Close Pane" className="absolute top-0 right-0 text-cyan-500 hover:text-white text-xl font-bold z-50 leading-none">[ X ]</button>
-                <h2 className="text-xl md:text-2xl font-bold mb-2 md:mb-4 text-cyan-400 tracking-widest text-center">[ EXPERIENCE ]</h2>
+                <button onClick={onClose} aria-label="Close Pane" className={`absolute top-0 right-0 text-cyan-500 hover:text-white ${isDesktop ? 'text-sm' : 'text-xl'} font-bold z-50 leading-none`}>[ X ]</button>
+                <h2 className={`${isDesktop ? 'text-sm mb-2' : isMobile ? 'text-lg mb-2' : 'text-xl mb-3'} font-bold text-cyan-400 tracking-widest text-center`}>[ EXPERIENCE ]</h2>
             </div>
-            
+
             {/* Main Content - Flex-1 to take remaining height, min-h-0 to allow nested scrolling */}
             <div className="flex-1 min-h-0 relative flex items-center">
                 {/* Nav Buttons */}
-                <button 
-                    onClick={handlePrev} 
-                    className={`absolute left-0 z-20 p-2 text-cyan-500 hover:text-white transition-colors bg-black/50 rounded-full hover:bg-cyan-900/30 ${isMobile ? '-ml-2' : ''}`}
+                <button
+                    onClick={handlePrev}
+                    className={`absolute left-0 z-20 ${isDesktop ? 'p-1.5' : 'p-2'} text-cyan-500 hover:text-white transition-colors bg-black/50 rounded-full hover:bg-cyan-900/30 ${isMobile ? '-ml-2' : ''}`}
                 >
-                    <FaChevronLeft size={isMobile ? 20 : 30} />
+                    <FaChevronLeft size={isDesktop ? 16 : isMobile ? 20 : 30} />
                 </button>
 
-                <div className="w-full h-full px-8 md:px-12 relative overflow-hidden">
+                <div className={`w-full h-full ${isDesktop ? 'px-6' : isMobile ? 'px-6' : 'px-8'} relative overflow-hidden`}>
                     <AnimatePresence initial={false} custom={direction} mode="wait">
                         <motion.div
                             key={currentIndex}
@@ -101,55 +124,82 @@ const ExperiencePane = ({ onClose }: PaneProps) => {
                                 x: { type: "spring", stiffness: 300, damping: 30 },
                                 opacity: { duration: 0.2 }
                             }}
-                            className="absolute inset-0 w-full h-full flex flex-col md:flex-row gap-4 md:gap-6 bg-white/5 rounded-lg border border-white/10 overflow-hidden"
+                            className={`absolute inset-0 w-full h-full flex flex-col lg:flex-row ${isDesktop ? 'gap-2' : 'gap-3 lg:gap-6'} bg-white/5 rounded-lg border border-white/10 overflow-hidden`}
                         >
                             {/* Image Section - Stacked image deck */}
-                            <div className={`${isMobile ? 'h-1/3 w-full' : 'w-5/12 h-full'} relative shrink-0 overflow-hidden group border-b md:border-b-0 md:border-r border-white/10`}>
+                            <div className={`${isDesktop ? 'w-2/5 h-full' : isMobile ? 'h-2/5 w-full' : 'w-full lg:w-5/12 h-1/3 lg:h-full'} relative shrink-0 overflow-hidden group border-b lg:border-b-0 lg:border-r border-white/10`}>
                                 {/* Padding for stack overflow (images peek top-left) */}
-                                <div className="absolute inset-0 p-4 md:p-6">
+                                <div className={`absolute inset-0 ${isDesktop ? 'p-2' : isMobile ? 'p-3' : 'p-4 lg:p-6'}`}>
                                     <StackedImageDeck
                                         images={currentItem.images || []}
                                         interval={3500}
+                                        link={currentItem.link}
+                                        imageLinks={currentItem.imageLinks}
+                                        onImageChange={setCurrentImageIndex}
                                     />
                                 </div>
-                                <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-transparent to-transparent md:bg-gradient-to-t md:from-black/80 pointer-events-none" />
-                                <div className="absolute bottom-2 left-3 md:bottom-4 md:left-4 z-10">
-                                     <h3 className="text-sm md:text-xl font-bold shadow-black drop-shadow-md">{currentItem.company}</h3>
-                                     <p className="text-xs md:text-sm text-cyan-300 shadow-black drop-shadow-md">{currentItem.period}</p>
+                                <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-transparent to-transparent pointer-events-none" />
+                                <div className={`absolute ${isDesktop ? 'bottom-1 left-2' : isMobile ? 'bottom-1 left-2' : 'bottom-2 left-3 lg:bottom-4 lg:left-4'} z-10`}>
+                                     <h3 className={`${isDesktop ? 'text-xs' : isMobile ? 'text-xs' : 'text-sm lg:text-xl'} font-bold shadow-black drop-shadow-md`}>{currentItem.company}</h3>
+                                     <p className={`${isDesktop ? 'text-[10px]' : isMobile ? 'text-[10px]' : 'text-xs lg:text-sm'} text-cyan-300 shadow-black drop-shadow-md`}>{currentItem.period}</p>
                                 </div>
                             </div>
 
                             {/* Text Section - Flex-1 with internal scroll */}
-                            <div className="flex-1 flex flex-col min-h-0 p-3 md:p-6 overflow-y-auto custom-scrollbar">
-                                <h3 className="text-lg md:text-2xl font-bold text-cyan-400 leading-tight">{currentItem.title}</h3>
-                                <h4 className="text-xs md:text-sm text-white/70 mb-3 md:mb-4 font-mono">{currentItem.role}</h4>
-                                <ul className="space-y-2">
+                            <div className={`flex-1 flex flex-col min-h-0 ${isDesktop ? 'p-2' : isMobile ? 'p-3' : 'p-3 lg:p-6'} overflow-y-auto custom-scrollbar`}>
+                                <h3 className={`${isDesktop ? 'text-sm' : isMobile ? 'text-base' : 'text-lg lg:text-2xl'} font-bold text-cyan-400 leading-tight`}>{currentItem.title}</h3>
+                                <h4 className={`${isDesktop ? 'text-[10px] mb-1' : isMobile ? 'text-[10px]' : 'text-xs lg:text-sm'} text-white/70 ${isDesktop ? '' : 'mb-2 lg:mb-4'} font-mono`}>{currentItem.role}</h4>
+                                <ul className={`${isDesktop ? 'space-y-0.5' : 'space-y-1 lg:space-y-2'}`}>
                                     {currentItem.highlights.map((highlight, idx) => (
-                                        <li key={idx} className="flex items-start gap-2 text-white/90 text-xs md:text-sm leading-relaxed">
-                                            <span className="text-cyan-500 mt-1 shrink-0">▹</span>
+                                        <li key={idx} className={`flex items-start ${isDesktop ? 'gap-1.5' : 'gap-2'} text-white/90 ${isDesktop ? 'text-[11px]' : isMobile ? 'text-[11px]' : 'text-xs lg:text-sm'} leading-relaxed`}>
+                                            <span className={`text-cyan-500 ${isDesktop ? '' : 'mt-0.5'} shrink-0`}>▹</span>
                                             <span>{highlight}</span>
                                         </li>
                                     ))}
                                 </ul>
+
+                                {/* Visit Link */}
+                                {linkInfo.url && linkInfo.label && (
+                                    <div className={`${isDesktop ? 'mt-2 pt-2' : 'mt-3 lg:mt-4 pt-2 lg:pt-3'} border-t border-white/10`}>
+                                        <AnimatePresence mode="wait">
+                                            <motion.a
+                                                key={linkInfo.label}
+                                                href={linkInfo.url}
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                className={`inline-flex items-center gap-2 text-cyan-400 hover:text-cyan-300 transition-colors ${isDesktop ? 'text-[11px]' : isMobile ? 'text-xs' : 'text-sm lg:text-base'} font-medium`}
+                                                initial={{ opacity: 0, y: 10 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                exit={{ opacity: 0, y: -10 }}
+                                                transition={{ duration: 0.3, ease: "easeInOut" }}
+                                            >
+                                                <span>Visit {linkInfo.label}</span>
+                                                <svg className={`${isDesktop ? 'w-3 h-3' : 'w-4 h-4'}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                                                </svg>
+                                            </motion.a>
+                                        </AnimatePresence>
+                                    </div>
+                                )}
                             </div>
                         </motion.div>
                     </AnimatePresence>
                 </div>
 
-                <button 
-                    onClick={handleNext} 
-                    className={`absolute right-0 z-20 p-2 text-cyan-500 hover:text-white transition-colors bg-black/50 rounded-full hover:bg-cyan-900/30 ${isMobile ? '-mr-2' : ''}`}
+                <button
+                    onClick={handleNext}
+                    className={`absolute right-0 z-20 ${isDesktop ? 'p-1.5' : 'p-2'} text-cyan-500 hover:text-white transition-colors bg-black/50 rounded-full hover:bg-cyan-900/30 ${isMobile ? '-mr-2' : ''}`}
                 >
-                    <FaChevronRight size={isMobile ? 20 : 30} />
+                    <FaChevronRight size={isDesktop ? 16 : isMobile ? 20 : 30} />
                 </button>
             </div>
-            
+
             {/* Pagination Indicators */}
-            <div className="shrink-0 flex justify-center gap-2 mt-3 h-4">
+            <div className={`shrink-0 flex justify-center ${isDesktop ? 'gap-1.5 mt-2 h-3' : 'gap-2 mt-3 h-4'}`}>
                 {experienceData.map((_, idx) => (
-                    <div 
-                        key={idx} 
-                        className={`w-2 h-2 rounded-full transition-all duration-300 ${idx === currentIndex ? 'bg-cyan-400 w-6' : 'bg-white/30'}`}
+                    <div
+                        key={idx}
+                        className={`${isDesktop ? 'w-1.5 h-1.5' : 'w-2 h-2'} rounded-full transition-all duration-300 ${idx === currentIndex ? `bg-cyan-400 ${isDesktop ? 'w-4' : 'w-6'}` : 'bg-white/30'}`}
                     />
                 ))}
             </div>

--- a/src/components/three/StackedImageDeck.tsx
+++ b/src/components/three/StackedImageDeck.tsx
@@ -7,13 +7,32 @@ interface StackedImageDeckProps {
   images: string[];
   interval?: number; // ms between shuffles
   className?: string;
+  link?: string;
+  imageLinks?: string[];
+  onImageChange?: (imageIndex: number) => void;
 }
 
 const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
   images,
   interval = 3500,
-  className = ''
+  className = '',
+  link,
+  imageLinks,
+  onImageChange
 }) => {
+  const getImageLink = (imageIndex: number): string | undefined => {
+    if (imageLinks && imageLinks[imageIndex]) {
+      return imageLinks[imageIndex];
+    }
+    return link;
+  };
+
+  const handleImageClick = (imageIndex: number) => {
+    const url = getImageLink(imageIndex);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  };
   // Track the order of images by their indices
   const [order, setOrder] = useState<number[]>(() =>
     images.map((_, i) => i)
@@ -39,6 +58,13 @@ const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
     setOrder(images.map((_, i) => i));
   }, [images]);
 
+  // Notify parent of current image change
+  useEffect(() => {
+    if (onImageChange && order.length > 0) {
+      onImageChange(order[0]);
+    }
+  }, [order, onImageChange]);
+
   if (!images || images.length === 0) {
     return (
       <div className={`w-full h-full bg-gray-800 flex items-center justify-center text-gray-500 ${className}`}>
@@ -58,10 +84,13 @@ const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
           // Cards further back have higher offset (peek from top-left)
           const offset = (maxVisibleCards - 1 - stackPosition) * stackOffset;
 
+          const currentLink = getImageLink(imageIndex);
+          const isClickable = isTop && !!currentLink;
+
           return (
             <motion.div
               key={imageIndex}
-              className="absolute inset-0 rounded-lg overflow-hidden shadow-2xl"
+              className={`absolute inset-0 rounded-lg overflow-hidden shadow-2xl ${isClickable ? 'cursor-pointer' : ''}`}
               style={{
                 zIndex: maxVisibleCards - stackPosition,
               }}
@@ -86,10 +115,11 @@ const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
                 stiffness: 300,
                 damping: 25,
               }}
+              onClick={isClickable ? () => handleImageClick(imageIndex) : undefined}
             >
               {/* Floaty drift animation for top card */}
               <motion.div
-                className="w-full h-full"
+                className={`w-full h-full ${isClickable ? 'group' : ''}`}
                 animate={isTop ? {
                   x: [0, 3, -2, 1, 0],
                   y: [0, -4, 2, -1, 0],
@@ -100,6 +130,7 @@ const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
                   ease: "easeInOut",
                   times: [0, 0.25, 0.5, 0.75, 1],
                 } : {}}
+                whileHover={isClickable ? { scale: 1.02 } : {}}
               >
                 <img
                   src={images[imageIndex]}
@@ -109,6 +140,15 @@ const StackedImageDeck: React.FC<StackedImageDeckProps> = ({
                 />
                 {/* Subtle vignette overlay */}
                 <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-black/20 pointer-events-none" />
+                {/* Link indicator for clickable top card */}
+                {isClickable && (
+                  <div className="absolute top-2 right-2 bg-black/60 text-cyan-400 px-2 py-1 rounded text-xs flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                    </svg>
+                    Visit
+                  </div>
+                )}
               </motion.div>
             </motion.div>
           );

--- a/src/hooks/use-responsive-pane.ts
+++ b/src/hooks/use-responsive-pane.ts
@@ -1,22 +1,84 @@
 import { useThree } from '@react-three/fiber';
 import { useMemo } from 'react';
 
-export function useResponsivePane(desktopWidth: number, desktopHeight: number) {
+export type BreakpointTier = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface ResponsivePaneConfig {
+  style: { width: string; height: string };
+  distanceFactor: number;
+  tier: BreakpointTier;
+  isPortrait: boolean;
+  isMobile: boolean;   // xs, sm, or md (stacked layouts)
+  isTablet: boolean;   // md only
+  isDesktop: boolean;  // lg or xl (side-by-side layouts)
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+interface TierConfig {
+  widthPercent: number;
+  maxWidth: number;
+  heightPercent: number;
+  maxHeight: number;
+  distanceFactor: number;
+}
+
+const TIER_CONFIGS: Record<BreakpointTier, TierConfig> = {
+  xs: { widthPercent: 0.95, maxWidth: 380,  heightPercent: 0.85, maxHeight: 600,  distanceFactor: 10 },
+  sm: { widthPercent: 0.90, maxWidth: 450,  heightPercent: 0.95, maxHeight: 900,  distanceFactor: 10 },
+  md: { widthPercent: 0.85, maxWidth: 650,  heightPercent: 0.85, maxHeight: 750,  distanceFactor: 11 },
+  lg: { widthPercent: 0.55, maxWidth: 700,  heightPercent: 0.65, maxHeight: 500,  distanceFactor: 17 },
+  xl: { widthPercent: 0.40, maxWidth: 750,  heightPercent: 0.35, maxHeight: 500,  distanceFactor: 20 },
+};
+
+function getTier(width: number): BreakpointTier {
+  if (width < 400) return 'xs';
+  if (width < 768) return 'sm';
+  if (width < 1200) return 'md';  // Extended tablet range
+  if (width < 1600) return 'lg';
+  return 'xl';
+}
+
+export function useResponsivePane(
+  maxWidth?: number,
+  maxHeight?: number
+): ResponsivePaneConfig {
   const { size } = useThree();
-  const isMobile = size.width < 768;
 
   return useMemo(() => {
-    // For desktop, ensure we don't exceed the actual window pixels
-    const width = isMobile ? 340 : Math.min(desktopWidth, size.width * 0.9);
-    const height = isMobile ? 600 : Math.min(desktopHeight, size.height * 0.85);
+    const tier = getTier(size.width);
+    const config = TIER_CONFIGS[tier];
+    const isPortrait = size.height > size.width;
+
+    // Calculate dimensions based on viewport percentages with constraints
+    let width = Math.round(size.width * config.widthPercent);
+    let height = Math.round(size.height * config.heightPercent);
+
+    // Apply tier max constraints
+    width = Math.min(width, config.maxWidth);
+    height = Math.min(height, config.maxHeight);
+
+    // Apply optional caller-specified max constraints
+    if (maxWidth) width = Math.min(width, maxWidth);
+    if (maxHeight) height = Math.min(height, maxHeight);
+
+    // Ensure minimum usable size
+    width = Math.max(width, 280);
+    height = Math.max(height, 400);
 
     return {
       style: {
         width: `${width}px`,
         height: `${height}px`,
       },
-      distanceFactor: isMobile ? 8 : 15,
-      isMobile,
+      distanceFactor: config.distanceFactor,
+      tier,
+      isPortrait,
+      isMobile: tier === 'xs' || tier === 'sm' || tier === 'md',
+      isTablet: tier === 'md',
+      isDesktop: tier === 'lg' || tier === 'xl',
+      viewportWidth: size.width,
+      viewportHeight: size.height,
     };
-  }, [size.width, size.height, isMobile, desktopWidth, desktopHeight]);
+  }, [size.width, size.height, maxWidth, maxHeight]);
 }

--- a/src/lib/experience-data.ts
+++ b/src/lib/experience-data.ts
@@ -5,6 +5,10 @@ export interface ExperienceItem {
   company: string;
   period: string;
   images?: string[];
+  link?: string;
+  linkLabel?: string;
+  imageLinks?: string[];
+  imageLinkLabels?: string[];
   highlights: string[];
 }
 
@@ -25,6 +29,26 @@ export const experienceData: ExperienceItem[] = [
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/tnsf/atombeamtech/Screenshot%202026-02-04%20171449.png',
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/tnsf/arilaw/Screenshot%202026-02-04%20171535.png',
     ],
+    imageLinks: [
+      'https://techinsf.com',
+      'https://techinsf.com',
+      'https://techinsf.com',
+      'https://techinsf.com',
+      'https://www.tidewatercap.com/',
+      'https://www.tidewatercap.com/',
+      'https://www.atombeamtech.com/',
+      'https://www.arilaw.com/',
+    ],
+    imageLinkLabels: [
+      'Tech In SF',
+      'Tech In SF',
+      'Tech In SF',
+      'Tech In SF',
+      'Tidewater Capital',
+      'Tidewater Capital',
+      'Atombeam',
+      'AriLaw',
+    ],
     highlights: [
       "Built and led Tech In SF's first internal engineering team — designing, engineering, and QA.",
       "Integrated AI tools into dev workflows (prompt chaining, QA bots, internal copilots), cutting project time-to-delivery by 50%.",
@@ -44,6 +68,8 @@ export const experienceData: ExperienceItem[] = [
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/samsung/Ambient-Mode-screen-brightness.webp',
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/samsung/TV_samsung_health_0.avif',
     ],
+    link: 'https://news.samsung.com/global/is-your-television-smart',
+    linkLabel: 'Samsung TV',
     highlights: [
       "Delivered interactive prototypes using Vue and React, bridging system architecture with UX goals.",
       "Collaborated across engineering and design to maintain experience integrity under real-world constraints.",
@@ -60,6 +86,8 @@ export const experienceData: ExperienceItem[] = [
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/williamssonoma/Screenshot%202026-02-04%20172412.png',
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/williamssonoma/Screenshot%202026-02-04%20172442.png',
     ],
+    link: 'https://www.williams-sonoma.com/',
+    linkLabel: 'Williams Sonoma',
     highlights: [
       "Developed core components for Search UI using atomic principles and shared libraries.",
       "Helped set new standards for frontend and design collaboration."
@@ -76,6 +104,8 @@ export const experienceData: ExperienceItem[] = [
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/apple/Screenshot%202026-02-04%20171317.png',
       'https://bizi8uwyyyejujyu.public.blob.vercel-storage.com/portfolio/apple/Screenshot%202026-02-04%20171400.png',
     ],
+    link: 'https://www.apple.com/store',
+    linkLabel: 'Apple Store',
     highlights: [
       "Apple Store content updates; wrote reusable SASS mixins; supported localization."
     ]


### PR DESCRIPTION
## Summary
- Experience cards now link to the actual websites/platforms
- **TechInSF**: rotating links per image (TechInSF, Tidewater Capital, Atombeam, AriLaw)
- **Samsung**: links to Samsung TV article
- **Williams Sonoma**: links to williams-sonoma.com
- **Apple**: links to Apple Store

## Changes
- `ExperienceItem` interface: added `link`, `linkLabel`, `imageLinks`, `imageLinkLabels`
- `StackedImageDeck`: clickable images with per-image link support
- `ExperiencePane`: animated link label that syncs to the currently visible image
- `useResponsivePane`: expanded breakpoint tiers (xs/sm/md/lg/xl) with `isDesktop`, `isTablet`, `tier`

Cherry-picked from `feature/responsive-pane-updates`.